### PR TITLE
fix: disableDependencyDashboard not found

### DIFF
--- a/default.json
+++ b/default.json
@@ -2,7 +2,7 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:base",
-    "disableDependencyDashboard",
+    ":disableDependencyDashboard",
     ":semanticCommitTypeAll(chore)",
     ":enableVulnerabilityAlertsWithLabel(security)",
     ":timezone(Asia/Tokyo)",


### PR DESCRIPTION
## Issues

closed #1 .

## Context

- [x] fix disableDependencyDashboard error
  - ref: https://docs.renovatebot.com/key-concepts/dashboard/#how-to-disable-the-dashboard