### PR TITLE
fix: add meteor, rangeStrategy, npm in default.json

### DIFF
--- a/default.json
+++ b/default.json
@@ -9,6 +9,13 @@
     "schedule:earlyMondays",
     ":enableVulnerabilityAlertsWithLabel(security)"
   ],
+  "meteor": {
+    "enabled": false
+  },
+  "rangeStrategy": "bump",
+  "npm": {
+    "commitMessageTopic": "{{prettyDepType}} {{depName}}"
+  },
   "prHourlyLimit": 0,
   "labels": ["🤖 renovate"],
   "enabledManagers": ["npm", "github-actions"]


### PR DESCRIPTION
## 🔗 Issue

## 📚 Description

- [x] `renovate-config-nuxt`で設定されているオプションを追加した
  - https://github.com/nuxt/renovate-config-nuxt/blob/2d8fc3771c8f4322f520316d3217ca69c178fa41/default.json