### PR TITLE
fix(kotlin): Add package names to JetBrains Kotlin group

### DIFF
--- a/config/kotlin/kotlin.json
+++ b/config/kotlin/kotlin.json
@@ -4,6 +4,11 @@
       "groupName": "JetBrains Official(Kotlin)",
       "groupSlug": "jetbrains",
       "matchSourceUrls": ["https://github.com/JetBrains/kotlin/"],
+      "matchPackageNames": [
+        "org.jetbrains.kotlin.jvm",
+        "org.jetbrains.kotlin.plugin.jpa",
+        "org.jetbrains.kotlin.plugin.spring"
+      ]
     },
   ]
 }


### PR DESCRIPTION
## 🔗 Issue

- #142 
- #150 

## 📚 Description

- [x] 想定通りにグループ化できていなかった。そのため明示に変更。

<img width="619" height="117" alt="image" src="https://github.com/user-attachments/assets/8623c462-89a1-40ba-a140-76c3ba35071b" />
