### PR TITLE
fix(ts): grouping `eslint-plugin`

### DIFF
--- a/config/linters.json
+++ b/config/linters.json
@@ -26,6 +26,12 @@
         "@stylistic/",
         "markdownlint"
       ]
+    },
+    {
+      "groupSlug": "eslint-plugins",
+      "matchPackageNames": [
+        "eslint-plugin-*"
+      ],
     }
   ]
 }


### PR DESCRIPTION
## 🔗 Issue

- closed #171 .

## 📚 Description

- [x] `eslint-plugin-*`をグループングしました

## 📓 Note

- `@intlify/eslint-plugin-vue-i18n`などのパターンは`**eslint-plugin-*`にした方が良いのか、それとも`eslint-plugin-*`でも検知するのか。不具合確認したらバグチケットを起票して対応する。