### PR TITLE
fix: add mermaid in matchPackageNames

### DIFF
--- a/config/vitepress.json
+++ b/config/vitepress.json
@@ -7,6 +7,7 @@
         "vitepress",
         "vitepress-openapi",
         "vitepress-plugin-mermaid",
+        "mermaid"
       ]
     }
   ]


### PR DESCRIPTION
## 📚 Description

- [x] mermaidを追加しました
  - `vitepress-plugin-mermaid`本体が`mermiad`の脆弱性対応を実施していない。脆弱性を回避するためには`mermaid`を明示的にインストールする必要がある。