### PR TITLE
fix(ci): Bump up to Node.js 24

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
     timeout-minutes: 2
     strategy:
       matrix:
-        node-version: [20.x]
+        node-version: [24.x]
     steps:
       - uses: actions/checkout@v5
       - name: 🤖 Use Node.js ${{ matrix.node-version }}


### PR DESCRIPTION
## 📚 Description

- [x] GitHub ActionsのNode.jsバージョンを**20.x**から**24.x**に更新しました 