### PR TITLE
chore(deps): bump up to setup-node v6 (use GHA)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - uses: actions/checkout@v5
       - name: 🤖 Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@2028fbc5c25fe9cf00d9f06a71cc4710d4507903 # v6.0.0
         with:
           node-version: ${{ matrix.node-version }}
 


### PR DESCRIPTION
## 📚 Description

- [x] setup-nodeのバージョン管理方法をGHA形式に変更しました