### PR TITLE
fix(config): add node.engines packageRules

### DIFF
--- a/default.json
+++ b/default.json
@@ -18,5 +18,14 @@
   },
   "prHourlyLimit": 0,
   "labels": ["🤖 renovate"],
-  "enabledManagers": ["npm", "github-actions"]
+  "enabledManagers": ["npm", "github-actions"],
+  "packageRules": [
+    {
+      "description": "Don't bump engines field in package.json",
+      "matchPackageNames": ["node"],
+      "matchManagers": ["npm"],
+      "matchDepTypes": ["engines"],
+      "rangeStrategy": "auto"
+    }
+  ]
 }


### PR DESCRIPTION
## 📚 Description

- [x] `node.engines`の更新PRを抑制
  - Node.jsのバージョン更新はLTS状況を見ながら手動で実施する方針。