### PR TITLE
chore(config): Add minimumReleaseAge configuration to default.json

### DIFF
--- a/default.json
+++ b/default.json
@@ -18,6 +18,7 @@
   },
   "prHourlyLimit": 0,
   "labels": ["renovate 🤖"],
+  "minimumReleaseAge": "5 days",
   "enabledManagers": [
     "npm",
     "gradle",


### PR DESCRIPTION
This pull request introduces a configuration update to the `default.json` file, setting a minimum release age for dependency updates.

Dependency update configuration:

* Added the `minimumReleaseAge` property with a value of `"5 days"` to ensure that only dependencies released at least five days ago are considered for updates.
