### PR TITLE
feat(ts): Rename group for unit test libraries and add vitest in list

### DIFF
--- a/config/nuxt/test-utils.json
+++ b/config/nuxt/test-utils.json
@@ -2,9 +2,10 @@
   "extends": ["packages:jsUnitTest"],
   "packageRules": [
     {
-      "groupName": "Unit Test libraries (using Nuxt Test Utils)",
+      "groupName": "Testing libraries",
       "groupSlug": "unit-tests",
       "matchPackageNames": [
+        "vitest",
         "@nuxt/test-utils",
         "@vue/test-utils",
         "happy-dom",


### PR DESCRIPTION
### 📚 Context

This pull request makes a minor update to the `config/nuxt/test-utils.json` file, focusing on improving clarity and coverage in dependency grouping for testing libraries.

- Renamed the group from "Unit Test libraries (using Nuxt Test Utils)" to "Testing libraries" to better reflect the grouped dependencies.
- Added `vitest` to the list of matched package names, ensuring it is included in the testing libraries group.
